### PR TITLE
feat: add Spinner component and bump @hivespace/shared to 1.1.16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,12 @@
 All development guidelines for this project have been consolidated into `CLAUDE.md`.
 
 Please read `CLAUDE.md` before making any changes in this repository.
+
+## Loading States (mandatory)
+
+Never write raw `<div class="animate-spin ...">` inline. Always use the shared components from `@hivespace/shared`:
+
+- **`<Spinner />`** — for inline/section loading (table, list, card content area). Props: `size` (`'sm'` | `'md'` | `'lg'`, default `'md'`).
+- **`<FullscreenLoader :visible="bool" :message="string" />`** — for full-UI blocking operations (form submit, destructive actions). Place at template root so it teleports to `<body>`.
+
+Decision rule: if the user cannot interact with the rest of the page while waiting → `FullscreenLoader`; otherwise → `Spinner`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,33 @@ For each new backend domain, follow these four steps in order:
 - **Composables**: Extract reusable stateful logic into `src/composables/` (e.g. `useModal.ts`, `usePagination.ts`). One composable per logical concern.
 - **Icons**: New SVG icons go into `src/icons/` as `.vue` components and must be exported from `src/icons/index.ts`.
 
+## Loading States
+
+Always use the shared loading components from `@hivespace/shared`. Never write raw `<div class="animate-spin ...">` inline.
+
+| Situation | Component | When to use |
+|---|---|---|
+| Data loading inside a page section (table, list, card) | `<Spinner />` | The rest of the page stays interactive; only the content area is replaced |
+| Blocking the entire UI (form submit, destructive action) | `<FullscreenLoader :visible="bool" :message="string" />` | User must not interact until the operation finishes |
+
+**`Spinner`** — props: `size` (`'sm'` \| `'md'` \| `'lg'`, default `'md'`). Import from `@hivespace/shared`.
+
+```vue
+<!-- inline table/list loading state -->
+<div v-if="appStore.isLoading" class="p-8 text-center">
+  <Spinner />
+  <p class="mt-2 text-gray-600 dark:text-gray-400">{{ $t('...loading') }}</p>
+</div>
+```
+
+**`FullscreenLoader`** — props: `visible` (boolean, required), `message` (string, optional). Import from `@hivespace/shared`. Place it at the root of the template so it teleports to `<body>`.
+
+```vue
+<FullscreenLoader :visible="submitting" :message="$t('...processing')" />
+```
+
+If unsure which to use, ask: "Does the user need to wait for this before doing anything else on the page?" → yes → `FullscreenLoader`; no → `Spinner`.
+
 ## Types & Interfaces
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fullcalendar/list": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
         "@fullcalendar/vue3": "^6.1.15",
-        "@hivespace/shared": "^1.1.10",
+        "@hivespace/shared": "^1.1.16",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.17",
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@hivespace/shared": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@hivespace/shared/-/shared-1.1.10.tgz",
-      "integrity": "sha512-CnwiNyMTPvht8ilNumK3tiuJFnxN4CCzWKEJy+ZmY2oRDhatKQVeOxNhcQmYI8aCVHCgb0kz7gixbz9adik0OA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@hivespace/shared/-/shared-1.1.16.tgz",
+      "integrity": "sha512-/jgZIuTXXObYSFxkXTCaszRuSly1UYV2VJHnMmgZpXgeD1NKsDLP2HpTfZQxqEMKy8OpwTia+QpO4Tp8+qpQEA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@fullcalendar/list": "^6.1.15",
     "@fullcalendar/timegrid": "^6.1.15",
     "@fullcalendar/vue3": "^6.1.15",
-    "@hivespace/shared": "^1.1.10",
+    "@hivespace/shared": "^1.1.16",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.17",

--- a/src/views/Accounts/AdminManagement.vue
+++ b/src/views/Accounts/AdminManagement.vue
@@ -41,7 +41,7 @@
 
           <!-- Loading State -->
           <div v-if="appStore.isLoading" class="p-8 text-center">
-            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <Spinner />
             <p class="mt-2 text-gray-600 dark:text-gray-400">{{ $t('admins.loading') }}</p>
           </div>
 
@@ -254,6 +254,7 @@ import {
   Badge,
   Input,
   Pagination,
+  Spinner,
   type AppUser,
 } from '@hivespace/shared'
 import { useModal, useConfirmModal, useFormatDate, useDebounce } from '@hivespace/shared'

--- a/src/views/Accounts/UserManagement.vue
+++ b/src/views/Accounts/UserManagement.vue
@@ -33,7 +33,7 @@
 
           <!-- Loading State -->
           <div v-if="appStore.isLoading" class="p-8 text-center">
-            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <Spinner />
             <p class="mt-2 text-gray-600 dark:text-gray-400">{{ $t('users.loading') }}</p>
           </div>
 
@@ -238,6 +238,7 @@ import {
   Badge,
   Input,
   Pagination,
+  Spinner,
 } from '@hivespace/shared'
 import {
   RefreshIcon,


### PR DESCRIPTION
## Summary
- Replace all inline `animate-spin` divs in `UserManagement` and `AdminManagement` with `<Spinner />` from `@hivespace/shared`
- Bump `@hivespace/shared` from `^1.1.10` to `^1.1.16`
- Add **Loading States** section to `CLAUDE.md` and `AGENTS.md` requiring use of `Spinner` and `FullscreenLoader` for all loading UI

## Test plan
- [ ] Visit User Management page — spinner renders correctly while data loads
- [ ] Visit Admin Management page — spinner renders correctly while data loads
- [ ] Verify no raw `animate-spin` divs remain in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive loading states guidance to developer documentation
* **Refactor**
  * Standardized loading indicators across accounts management interfaces with consistent shared components
* **Chores**
  * Updated `@hivespace/shared` dependency to latest compatible version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->